### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ requests==2.13.0
 six==1.10.0
 Werkzeug==0.12.1
 gunicorn
+pyOpenSSL==17.5.0


### PR DESCRIPTION
we need pyOpenSSL now for travis signing. I'm sorry, I didn't test in a virtualenv, I will do that next time. I think this is the only added dependency (urllib is in the standard library)